### PR TITLE
Add initial Makefile and spec.in file for packaging as RPM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+APPNAME  = punchtime
+VERSION  = $(shell git describe --always --match 'v[0-9]*' \
+		| sed -e 's/^v//' -e 's,-,.,g')
+TARNAME  = $(APPNAME)-$(VERSION)
+
+SPECIN = punchtime.spec.in
+SPECFILE = $(SPECIN:.in=)
+
+default: srpm
+
+.PHONY: tar
+tar: dist/$(TARNAME).tar.gz
+
+.PHONY: srpm
+srpm: tar
+	@rpmbuild -ts dist/$(TARNAME).tar.gz
+
+.PHONY: rpm
+rpm: tar
+	@rpmbuild -tb dist/$(TARNAME).tar.gz
+
+dist/$(TARNAME).tar.gz: $(SPECFILE)
+	@echo "Creating dist/$(TARNAME).tar.gz"
+	@mkdir -p dist/$(TARNAME)
+	@echo "$(VERSION)" > dist/$(TARNAME)/VERSION
+	@rm -f dist/$(TARNAME).tar.gz
+	@git archive --format=tar --prefix=$(TARNAME)/ \
+		HEAD > dist/$(TARNAME).tar
+	@tar -C dist --owner=root --group=root -r -f dist/$(TARNAME).tar \
+		$(TARNAME)/
+	@gzip -f -9 dist/$(TARNAME).tar
+	@rm -rf dist/$(TARNAME)
+
+$(SPECFILE): $(SPECIN)
+	@mkdir -p dist/$(TARNAME)
+	@sed -e "s/@@VERSION@@/$(VERSION)/g" \
+		< $(SPECIN) > dist/$(TARNAME)/$(SPECFILE)
+
+.PHONY: clean
+clean:
+	@rm -rf dist
+

--- a/punchtime.spec.in
+++ b/punchtime.spec.in
@@ -1,0 +1,45 @@
+%define punchtime_daemon_prefix /usr/sbin
+%define punchtime_client_prefix /usr/bin
+
+Summary: Time clock daemon in client/server Python fashion
+Name: punchtime
+Version: @@VERSION@@
+Release: 1%{?dist}
+Group: Applications/Productivity
+License: Proprietary
+
+Source0: %{name}-%{version}.tar.gz
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+
+BuildArch: noarch
+
+%description
+Punchtime is a Python-based command-line time clock system.  It is used for
+tracking and reporting the hours worked by employees.  The punchtimed daemon is
+responsible for accessing and updating punchcard data in response to signals
+from the punchtime client.
+
+%prep
+%setup
+
+%build
+
+%install
+%{__rm} -rf %{buildroot}
+%{__mkdir_p} %{buildroot}%{punchtime_daemon_prefix}
+%{__mkdir_p} %{buildroot}%{punchtime_client_prefix}
+
+%{__cp} punchtimed.py %{buildroot}%{punchtime_daemon_prefix}/punchtimed.py
+%{__cp} punchtime.py %{buildroot}%{punchtime_client_prefix}/punchtime.py
+
+%clean
+%{__rm} -rf %{buildroot}
+
+%files
+%defattr(-,root,root,0755)
+%{punchtime_daemon_prefix}/punchtimed.py
+%{punchtime_client_prefix}/punchtime.py
+
+%changelog
+* Tue Apr 28 2015 Alex Schorsch <schorsch@stanford.edu>
+- Initial package.


### PR DESCRIPTION
This is an initial attempt at packaging punchtime as an rpm.  We may want to tweak the description and should probably add an init.d script.